### PR TITLE
commented out non-existent header file "arduino.h"

### DIFF
--- a/example/zbot/MeBuzzer.cpp
+++ b/example/zbot/MeBuzzer.cpp
@@ -1,5 +1,5 @@
 #include "MeBuzzer.h"
-#include "arduino.h"
+//#include "arduino.h"
 
 #include <avr/io.h>
 #include <stdint.h>


### PR DESCRIPTION
Somehow "arduino.h" prevents zbot example to be built. Tried this on a platform.io environment and the project builds fine with the commented header file.